### PR TITLE
Modify introduction in Slack article

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -1,10 +1,10 @@
 # Slack guidelines
 
-Hi and welcome to Slack!
+Hi and welcome to Receipt Bank!
 
 It's nice to have you here!
 
-This document will acquaint you with how we do things around here. It's pretty big and we like to
+This document will acquaint you with how we use Slack around here. It's pretty big and we like to
 keep it organised. Please read this document carefully and follow the instructions.
 
 ## Your Slack profile


### PR DESCRIPTION
What            | Where/Who
----------------|----------------------------------------
Reviewers       | @skanev @mitio @Dsmilyanov @gmitrev

The Slack guide was copied from the old Slack document. Its introduction read:

```
Hi and welcome to Slack!

It's nice to have you here!
```

Such introduction would be fine for new colleagues who received the link in Slack. For users outside the company however this would make no sense - they would land on a web page, not in a Slack channel.

The introduction was modified to accomodate broader audience.
