### PR TITLE
Update slack guidelines naomi

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -43,47 +43,15 @@ Feel free to create new channels any time you will need to. Here are some guidel
 
 Keep in mind that channel names are unique, even for private channels. If you intend to create multiple channels for related topics, it is nice to prefix them with a single short word or abbreviation.
 
-## Messaging users
+## Messaging people
 
-Slack is intended for asynchronous communication. This means that people don't need to be in it at
-the same time – somebody can message you now you can reply later when you see the message. In
-practice, this means two things:
+Slack is intended for asynchronous communication. This means that people don't need to be in it at the same time – somebody can message you now and you can reply later, when you see the message. In practice, this means two things:
 
-* It's perfectly OK to message anybody at any time. They are neither expected to see it immediately
-  nor to reply straight away. They can answer when they have the time or in between other tasks.
-  Don't expect people to respond instantly.
-* If there is an emergency, it's not the best way to get somebody's attention. That's why you had
-  to fill in your phone number earlier – if you need somebody right this minute, consider phoning
-  or messaging them. Don't do this unless it's really important – people need to be able to focus
-  to get work done and interruptions are the productivity killer.
+* It's perfectly OK to message anybody at any time. Nobody’s expected to see it or reply straight away. People will answer when they have the time or if it’s after-hours for them expect a response on their next working day.
+* If there is an emergency, it's not the best way to get somebody's attention. That's why we have our phone numbers in the Slack profile – if you need somebody right this minute, consider phoning or messaging them. But please don't do this unless it's really important – people need to be able to focus and get the work done. Interruptions are the productivity killer.
+* For important announcements that need to be seen by everybody Slack is not going to be enough, send those by email as well.
 
-Apart from that, feel free to contact anybody about anything.
-
-While we are at it, try to avoid the cardinal sin in Slack. It's sending a message with...
-
-> Hi!
-
-...and following by saying nothing.
-
-Remember, Slack is asynchronous. If you wait for the person you need to be online on the same time,
-you're breaking their flow. It forces them to constantly look at Slack so you two can be online at
-the same time. There is nothing wrong with pleasantries (our HQ is in Britain after all), but
-include why you are contacting the person and preferably something actionable for them to do. If
-you have a question about the Automation Platform and you think you might want to have a meeting,
-don't just say "Hi, can we talk?" or "Can we have a meeting later today?". Add some context and
-some plan of action:
-
-> Hey! I've been looking at the Automation Platform and I have a question. I'm wondering if directly
-  processes 1Tap receipts, or if they need to go through Receipt Bank for Accountants first. Do you
-  think we can have a meeting about that?
-
-This is much better! It doesn't just give the other person context about why you are contacting
-them – it also tells them what your question is. This gives them an opportunity to prepare a bit
-for the meeting, or even better – answer you right there in Slack and have no meeting at all
-(usually the best kind of meeting). Remember, the fewer interruptions we have, the more work we can
-get done.
-
-And that's all you need to know on messaging users.
+Avoid the cardinal sin of sending just “Hi” and waiting for the other side to reply. There is nothing wrong with pleasantries, but include why you are contacting the person and preferably something actionable for them to do. If you have a question and you think you might want to have a meeting, don't just say "Hi, can we talk?" or "Can we have a meeting later today?". Add some context and allow them to give you a meaningful reply.
 
 ## Statuses
 

--- a/slack.md
+++ b/slack.md
@@ -55,20 +55,11 @@ Avoid the cardinal sin of sending just “Hi” and waiting for the other side t
 
 ## Statuses
 
-Please use statuses only as means to communicate availability with the other team members. The two
-most commonly used statuses should be ":palm_tree: Vacationing" and ":face_with_thermometer: Out
-Sick". Occasionally it might be good to set a custom status if you're working weird hours or harder
-to reach.
+The two most commonly used statuses should be "🌴 Vacationing" and “🤒 Out sick". 
 
-When you set your status to ":palm_tree: Vacationing", always edit the default text and say when
-you'll be back, e.g. "Vacationing (back on Sept 25th)". This will be very convenient for people who
-want to contact you as they'll immediately see when you'll be back. In addition to this, feel free
-to use Slack's feature to automatically remove the vacationing status on a certain date.
+Please use statuses only as means to communicate availability or if your current situation is atypical. If you are always working remotely, there is no point in setting "🏡 Working Remotely". Also, avoid setting status only as a joke.
 
-Set a status only if your current situation is untypical and you want to communicate this to the
-rest of the team. If you are always working remotely, there is no point in setting ":house: Working
-Remotely". Also, please avoid setting status only to be cute or funny – they should be used to
-communicate availability with the team, not express moods.
+When you set your status to "🌴 Vacationing", edit the default text to add when you'll be back, e.g. "Vacationing (back on Sept 25th)". This is very useful for people who want to contact you as they'll immediately see when you'll be back.
 
 ## Still got questions?
 

--- a/slack.md
+++ b/slack.md
@@ -35,7 +35,7 @@ There are many channels for various topics, so it might be worth it to give a qu
 Feel free to create new channels any time you will need to. Here are some guidelines:
 
 * Separate words in the channel name with dashes `-`, not underscores `_`. Like `#baking-recipes` or `#feature-requests`.
-* Always, **always add a topic to the channel**. Note that this can only be done after the channel is created. Anybody reading it should get a good sense of what the channel is about. And remember that not everybody is in your department, so make sure that you include enough context for everybody.
+* Always, **always add a topic to the channel**. Note that there is a difference between topic and description. The topic can be added/updated once the channel is created. Anybody reading the topic should get a good sense of what the channel is about. Remember that not everybody is in your department, so make sure that you include enough context for everybody.
 * Some channels are in Bulgarian. That's perfectly fine as Slack is very heavily used by the Engineering team in Bulgaria. Those channels have a 🇧🇬 Bulgarian flag in the topic.
 * Some channels are expected to be thread-only. This is indicated with the `:speech_balloon:` emoji 💬.
 * When your channel is not needed anymore, please archive it.

--- a/slack.md
+++ b/slack.md
@@ -21,48 +21,27 @@ If you're an engineer, make sure **your username in Slack matches the one in Git
 
 ## Channels
 
-For starts, hop in the following channels:
+You should already be in the following channels. Please join them if you are not.
 
-* `#general` – this one is for general Receipt Bank related conversations.
-* `#company-announcements` – this channel is for company updates and announcements you may want to 
-  share with the rest of the company.
-* `#random` – use it for jokes, cat pictures or baking recipes.
-* `#hellos-goodbyes` – if you are new, introduce yourself here.
-* `#all-hands-meeting` - notes and recordings from all-hands meetings.
+* `#general` – Company-wide announcements and updates. What gets posted here is important, so we try to limit the volume of conversation and use threads, so that messages don’t get lost.
+* `#random` – Fun stuff. Anything that is non work related to keep us connected and remind us to be lighthearted.
+* `#hellos-goodbyes` – Say hello. Introduce yourself here.
+* `#all-hands-meeting` - Notes and recordings from all-hands meetings.
 
-There are various channels for various topics, so it might be worth it to give a quick glance over
-the list of channels and see if you're interested in any. Don't fret too much about it – if you are
-needed in a channel, people can easily invite you.
+There are many channels for various topics, so it might be worth it to give a quick glance over the list and see if you're interested in any. But don't fret too much about it – if you are needed somewhere, people will invite you.
 
-On the same note, feel free to open a channel any time you will want to have a conversation with a
-broader circle of people. Just make sure you do the following:
+## Creating new channels
 
-* If the channel consists of multiple words, separate them with dashes (-), not underscores (_),
-  like `#baking-recipes` or `#feature-requests`. In devspeak this is lovingly called "kebab case"
-  because all the words look like they are all held together on a shish kebab.
-* Always, always, **always set a channel purpose and topic**. The person reading it should get a good
-  sense of what this channel is all about. Remember that not everybody is in your department, so
-  make sure that you include enough context for the purpose to make sense to everybody. We
-  occasionally prune channels in order to keep the list manageable and purposes are of big help.
-  The topic is visible every time you look at the channel, so it should be a short reminder of what
-  it is about. The purpose can have a longer description.
-* Some channels are in Bulgarian. That's perfectly fine as Slack is very heavily used by the dev
-  team and they have many channels. They don't follow a special nomenclature (which would be
-  heavily inconvenient), but they will be indicated with a Bulgarian flag (:flag-bg:) in the topic.
-* Some channels used by the Dev team are expected to be thread-only. They are indicated with
-  the `:speech_balloon:` emoji (:speech_balloon:).
-* If your channel has a lifespan (you want to have a conversation around a topic and once it's
-  over, you're done – you may want to reach a decision in a group, for example), it's nice to
-  archive once you're done with it.
-* Don't use private channels, unless you really need to. We try to keep a culture of transparency
-  here. All team channels in particular should be public - if you find yourself in a private team
-  channel, please archive it and create a new public one.
+Feel free to create new channels any time you will need to. Here are some guidelines:
 
-Keep in mind that channel names are unique, even for private channels. If you intend to create
-multiple channels for related topics, it is nice to prefix them with a single short word or
-abbreviation.
+* Separate words in the channel name with dashes `-`, not underscores `_`. Like `#baking-recipes` or `#feature-requests`.
+* Always, **always add a topic to the channel**. Note that this can only be done after the channel is created. Anybody reading it should get a good sense of what the channel is about. And remember that not everybody is in your department, so make sure that you include enough context for everybody.
+* Some channels are in Bulgarian. That's perfectly fine as Slack is very heavily used by the Engineering team in Bulgaria. Those channels have a 🇧🇬 Bulgarian flag in the topic.
+* Some channels are expected to be thread-only. This is indicated with the `:speech_balloon:` emoji 💬.
+* When your channel is not needed anymore, please archive it.
+* Don't use private channels, unless you really, really need to. We’re trying to keep a culture of transparency here. All team channels should be public - if you find yourself in a private team channel, ask to archive it and create a new public one.
 
-That's all about channels. Now let's look into messaging users.
+Keep in mind that channel names are unique, even for private channels. If you intend to create multiple channels for related topics, it is nice to prefix them with a single short word or abbreviation.
 
 ## Messaging users
 

--- a/slack.md
+++ b/slack.md
@@ -1,11 +1,6 @@
 # Slack guidelines
 
-Hi and welcome to Receipt Bank!
-
-It's nice to have you here!
-
-This document will acquaint you with how we use Slack around here. It's pretty big and we like to
-keep it organised. Please read this document carefully and follow the instructions.
+This page will acquaint you with how we use Slack in Receipt Bank. It's organized by topic. Please read it carefully and follow the instructions.
 
 ## Your Slack profile
 

--- a/slack.md
+++ b/slack.md
@@ -2,37 +2,22 @@
 
 This page will acquaint you with how we use Slack in Receipt Bank. It's organized by topic. Please read it carefully and follow the instructions.
 
-## Your Slack profile
+## Slack profile
 
-Your [Slack profile](https://receipt-bank.slack.com/account/profile) is what your co-workers see
-about you. Having offices around the globe tends to make us a remote company, so it's important
-that your co-workers in far-away countries can get a good sense of you. Please fill in your profile
-neatly. It's best to fill in all fields, but the following are mandatory:
+[Your Slack profile](https://receipt-bank.slack.com/account/profile) is the first thing most of your coworkers see about you. Please fill it in neatly. It's best to fill in all the fields, but the following are mandatory:
 
-* **First name** and **Last name**. Use your full real name here.
-* **What I do.** This is shown under your picture in Slack. You can enter your official role here
-  or anything else that you think will help your coworkers understand what you do.
-* **Phone number.** Enter your phone number here. We won't use it, unless it's an emergency.
-* **Time Zone.** Be sure to specify it – it will help show Slack what the time is where you are if
-  they want to contact you.
-* **Role.** This is your official role, as per your role description.
+* **Full name.** Use your real names here.
+* **What I do.** This is shown under your picture in Slack. You can enter your official role or anything else that will help your coworkers understand what you do.
+* **Phone number.** Please enter your phone number. It’s not going to be used, unless it's an emergency.
+* **Time Zone.** It will help Slack and anyone who wants to contact you know what the time it is for you.
+* **Role.** Enter your official role, as per your role description.
 * **Location.** Where in the world you work from. Useful, since we're all around the globe.
-* **Team.** Which team are you a part of?
-* **Manager.** Enter the person you report to. If you are uncertain, that is usually the person you
-  have your one-to-ones with. If you can't find them, they might not be in Slack yet – make sure
-  you fill it once they are.
+* **Team.** Which team are you a part of.
+* **Manager.** Enter the person you report to. If you are uncertain, that is usually the person you have your one-to-ones with. If you can't find them, they might not be in Slack yet – make sure you fill it once they are.
 
-Please fill in all of the above in your profile. Fill in the other if you'd like.
+**Upload an Image**. It makes Slack considerably more personal. Don't just put in any picture there – use a photo where we can see your face and you can be identified. Bonus points if you manage to get in orange background with the Receipt Bank logo.
 
-The next step is to **upload a profile picture**. This is a **must have**, as it makes Slack
-considerably more personal. Don't just put in any picture there – use a photo where we can see your
-face and you can be identified. Bonus points if you manage to get in orange background with the
-Receipt Bank logo.
-
-Finally, if you're a developer or working with code, make sure **your username in Slack matches the
-one in GitHub**. If you don't have GitHub, you can ignore this.
-
-That's it – you're done with your profile. Let's look at some ground rules.
+If you're an engineer, make sure **your username in Slack matches the one in GitHub**. If you don't have GitHub, you can ignore this.
 
 ## Channels
 


### PR DESCRIPTION
What            | Where/Who
----------------|----------------------------------------
Reviewers       | @skanev @mitio @gmitrev

This is an update of the Slack guidelines. It aims to refresh the language a bit to fit more with the wider audience of Receipt Bank in 2020.
* Slack profile section is updated to reflect the fields of the profile in the current version of Slack
* The channel list is updated to reflect the merge of #general and #company-announcements
* The rest is mild rewording agreed with Naomi